### PR TITLE
Fix the xxhash include. 

### DIFF
--- a/hashing.go
+++ b/hashing.go
@@ -1,7 +1,7 @@
 package hyperbloom
 
 import (
-	XXHN "github.com/oneofone/xxhash/native"
+	XXHN "github.com/OneOfOne/xxhash"
 )
 
 func hashEntry(entry []byte, n int) []uint64 {


### PR DESCRIPTION
This library as not building, because it relies on https://github.com/OneOfOne/xxhash/native, which no longer exists. The native branch was moved to https://github.com/OneOfOne/xxhash . The library has been updated to reflect that.